### PR TITLE
feat: 알림 페이지 개발

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -24,6 +24,8 @@ import MyPage from "@/pages/My/MyPage";
 import PeoplePage from "@/pages/Home/BandDetailPage/PeoplePage";
 import PlaylistPage from "@/pages/Home/BandDetailPage/PlaylistPage";
 import PreferPage from "@/pages/Home/BandDetailPage/PreferPage";
+import NotificationPage from "@/pages/Notification/NotificationPage";
+import NotificationDetailPage from "@/pages/Notification/NotificationDetailPage";
 
 const routes = [
   {
@@ -48,6 +50,8 @@ const routes = [
       { path: "/manual", element: <ManualPage /> },
       { path: "/settings", element: <SettingsPage /> },
       { path: "/my", element: <MyPage /> },
+      { path: "/my/notifications", element: <NotificationPage /> },
+      { path: "/my/notifications/:id", element: <NotificationDetailPage /> },
       { path: "*", element: <NotFoundPage /> },
       //Home 관련 페이지
       { path: "/", element: <HomePage /> },

--- a/src/pages/My/MyPage.tsx
+++ b/src/pages/My/MyPage.tsx
@@ -38,7 +38,7 @@ const MyPage = () => {
       <Header
         title="MY"
         rightIcon={<img src={hasNotification ? bell : no_bell} alt="bell" className="text-[#FFFFFF] mb" />}
-        rightLink={"/notifications"}
+        rightLink={"/my/notifications"}
       />
       <div className="mt-[15vh]"></div>
       <ProfileInfo

--- a/src/pages/Notification/NotificationDetailPage.tsx
+++ b/src/pages/Notification/NotificationDetailPage.tsx
@@ -1,0 +1,43 @@
+import { useNavigate } from "react-router-dom";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import arrow_back from "@/assets/icons/back.svg";
+import CommonBtn from "@/shared/components/CommonBtn";
+
+export default function NotificationDetailPage() {
+  const navigate = useNavigate();
+  // const { id } = useParams();
+
+  // 일단은 목데이터
+  const notification = {
+    icon: <img src="https://i.playboard.app/p/AATXAJx9xhPSANXOwHmFoY6GExI19QhCC8STelIzPP6J/default.jpg" alt="apple" className="w-[44vw] h-[44vw] rounded-full" />,
+    name: "링고",
+    type: "매칭 요청",
+  };
+
+  return (
+    <div className="min-h-[100dvh] w-full flex flex-col items-center bg-[radial-gradient(ellipse_at_center,_#551013_0%,_#121212_100%)]">
+      <header className="absolute top-0 left-0 w-full flex items-center h-[13vh] px-[4vw] text-[#FFFFFF]">
+        <button
+          type="button"
+          onClick={() => navigate(-1)}
+          className="mr-2"
+        >
+          <img src={arrow_back} alt="arrow-back" className="w-[10vw] h-[10vw]" />
+        </button>
+        <span className="text-[#e5e7eb] text-hakgyo-b-17 ml-[3vw]">전체 알림</span>
+      </header>
+      <div className="flex flex-col items-center justify-center flex-1 w-full min-h-[70vh]">
+        <div>{notification.icon}</div>
+        <div className="flex justify-center items-center mt-[3vh]">
+          <ChevronLeft size={24} className="text-[#FFFFFF]/70 mr-[3vw] invisible" />
+          <div className="text-[#FFFFFF] text-hakgyo-b-24">{notification.name}</div>
+          <ChevronRight size={24} className="text-[#FFFFFF]/70 ml-[3vw] cursor-pointer" onClick={() => navigate("/profile-detail")} />
+        </div>
+        <div className="flex gap-[3vw] mt-[6vh]">
+          <CommonBtn color="gray">거절</CommonBtn>
+          <CommonBtn color="red">채팅 수락</CommonBtn>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Notification/NotificationPage.tsx
+++ b/src/pages/Notification/NotificationPage.tsx
@@ -1,0 +1,9 @@
+import NotificationList from "./_components/NotificationList";
+
+export default function NotificationPage() {
+  return (
+    <div className="min-h-[100dvh] w-full bg-[#1C1C1E] flex flex-col">
+      <NotificationList />
+    </div>
+  );
+}

--- a/src/pages/Notification/_components/NotificationItem.tsx
+++ b/src/pages/Notification/_components/NotificationItem.tsx
@@ -1,0 +1,27 @@
+import { ChevronRight } from "lucide-react";
+
+interface NotificationItemProps {
+  avatarUrl?: string;
+  icon?: React.ReactNode;
+  message: string;
+  onClick?: () => void;
+}
+
+export default function NotificationItem({ avatarUrl, icon, message, onClick }: NotificationItemProps) {
+  return (
+    <div
+      className="flex items-center py-[3vh] hover:bg-[#FFFFFF]/10 transition rounded-lg cursor-pointer"
+      onClick={onClick}
+    >
+      <div className="w-[16vw] h-[16vw] rounded-full bg-[#808080] flex items-center justify-center overflow-hidden flex-shrink-0 mr-[4vw]">
+        {avatarUrl ? (
+          <img src={avatarUrl} alt="avatar" className="w-full h-full object-cover" />
+        ) : (
+          icon
+        )}
+      </div>
+      <span className="text-[#FFFFFF] flex-1 text-left text-hakgyo-r-16">{message}</span>
+      <ChevronRight size={22} className="text-[#FFFFFF]/70 text-left ml-[2vw]" />
+    </div>
+  );
+}

--- a/src/pages/Notification/_components/NotificationList.tsx
+++ b/src/pages/Notification/_components/NotificationList.tsx
@@ -1,0 +1,57 @@
+import NotificationItem from "./NotificationItem";
+import { AlertCircle } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+
+const notifications = [
+  {
+    id: "1",
+    icon: <img src="/assets/apple.png" alt="apple" className="w-8 h-8" />, // 예시: 사과 아이콘
+    name: "링고",
+    message: "'링고' 님이 매칭을 요청하셨습니다.",
+    type: "matching",
+  },
+  {
+    id: "2",
+    avatarUrl: "/assets/band.jpg",
+    message: "'우리밴드 정상영업합니다' 밴드에서 당신을 원합니다.",
+    type: "band",
+  },
+  {
+    id: "3",
+    avatarUrl: "/assets/flowerboy.jpg",
+    message: "'Flowerboy' 님이 당신을 원합니다.",
+    type: "matching",
+  },
+  {
+    id: "4",
+    icon: <AlertCircle size={28} className="text-red-500" />,
+    message: "제제 내역입니다.",
+    type: "ban",
+  },
+];
+
+export default function NotificationList() {
+  const navigate = useNavigate();
+
+  if (notifications.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center w-full h-full">
+        <span className="text-gray-400 text-base">새 소식이 없습니다.</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col px-[3vw]">
+      {notifications.map((n) => (
+        <NotificationItem
+          key={n.id}
+          avatarUrl={n.avatarUrl}
+          icon={n.icon}
+          message={n.message}
+          onClick={() => navigate(`/my/notifications/${n.id}`)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/widgets/Layout/BottomBar.tsx
+++ b/src/widgets/Layout/BottomBar.tsx
@@ -25,7 +25,14 @@ const BottomBar = () => {
       aria-label="하단 내비게이션 바"
     >
       {navs.map((nav) => {
-        const active = location.pathname === nav.path;
+        let active = false;
+        if (nav.path === "/") {
+          active = location.pathname === "/";
+        } else if (nav.path === "/my") {
+          active = location.pathname.startsWith("/my") || location.pathname.startsWith("/profile-other/");
+        } else {
+          active = location.pathname.startsWith(nav.path);
+        }
         return (
           <Link
             key={nav.path}

--- a/src/widgets/Layout/Header.tsx
+++ b/src/widgets/Layout/Header.tsx
@@ -8,6 +8,7 @@ const routeNameMap: Record<string, string> = {
   "/search": "Search",
   "/band": "Band",
   "/my": "My",
+  "/my/notifications": "Notifications",
   // 필요시 추가
 };
 
@@ -17,28 +18,50 @@ const Header = () => {
   const routeName = routeNameMap[location.pathname] || "";
   const depth = location.pathname.split("/").filter(Boolean).length;
 
-  return (
-    <header className="w-full h-14 flex items-center px-4 bg-transparent">
-      {depth >= 2 ? (
+  if (depth >= 2 && !routeName) {
+    // 뒤로가기 버튼만
+    return (
+      <header className="w-full h-14 flex items-center px-4 bg-transparent">
         <button
           onClick={() => navigate(-1)}
           className="w-8 h-8 flex items-center justify-center focus:outline-none"
         >
           <img src={backIcon} alt="Back" className="w-8 h-8" />
         </button>
-      ) : (
-        <>
-          <img src={whiteStar} alt="Banddy Logo" className="w-8 h-8" />
-          <span
-            className="ml-4 text-white text-xl font-bold italic"
-            style={{ fontFamily: "Helvetica, Arial, sans-serif" }}
-          >
-            {routeName}
-          </span>
-        </>
-      )}
-    </header>
-  );
+      </header>
+    );
+  } else if (depth >= 2 && routeName) {
+    // 뒤로가기 버튼 + routeName
+    return (
+      <header className="w-full h-14 flex items-center px-4 bg-transparent">
+        <button
+          onClick={() => navigate(-1)}
+          className="w-8 h-8 flex items-center justify-center focus:outline-none"
+        >
+          <img src={backIcon} alt="Back" className="w-8 h-8" />
+        </button>
+        <span
+          className="ml-4 text-white text-xl font-bold italic"
+          style={{ fontFamily: "Helvetica, Arial, sans-serif" }}
+        >
+          {routeName}
+        </span>
+      </header>
+    );
+  } else {
+    // (depth < 2) 로고 + routeName
+    return (
+      <header className="w-full h-14 flex items-center px-4 bg-transparent">
+        <img src={whiteStar} alt="Banddy Logo" className="w-8 h-8" />
+        <span
+          className="ml-4 text-white text-xl font-bold italic"
+          style={{ fontFamily: "Helvetica, Arial, sans-serif" }}
+        >
+          {routeName}
+        </span>
+      </header>
+    );
+  }
 };
 
 export default Header;

--- a/src/widgets/Layout/Layout.tsx
+++ b/src/widgets/Layout/Layout.tsx
@@ -13,10 +13,11 @@ export default function Layout() {
     "/signup/profile",
     "/signup/complete",
   ].some((path) => location.pathname.startsWith(path));
+  const hideHeader = ["/my/notifications/"].some((path) => location.pathname.startsWith(path));
 
   return (
     <div className="relative min-h-screen min-h-[100dvh] flex flex-col bg-[#121212] overflow-hidden w-full">
-      <Header />
+      {!hideHeader && <Header />}
       <main className="flex-1 flex flex-col items-center justify-center  w-full max-w-md mx-auto gap-y-8">
         <Outlet />
       </main>


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요. -->

- #16 

## 📌 PR 내용

<!-- PR 내용을 설명해주세요. -->

<img width="347" height="628" alt="스크린샷 2025-07-13 오후 12 57 14" src="https://github.com/user-attachments/assets/f850bc6e-daf2-4b9b-a986-9c4364803319" />

- 알림 페이지 개발

<img width="347" height="624" alt="스크린샷 2025-07-13 오후 12 57 26" src="https://github.com/user-attachments/assets/2b10117c-993a-4a01-a6e5-6691dfcec58b" />

- 알림 디테일 페이지 개발

## 🗣️ 팀원에게 공유할 내용

<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->
<img width="316" height="33" alt="스크린샷 2025-07-13 오후 12 56 35" src="https://github.com/user-attachments/assets/de72eb6b-ccb4-4cc3-adce-e2c8f7f3a436" />

- 현재 알림 디테일 페이지의 경우, 헤더가 특수한 경우라, 레이아웃에서 제외하였고 재사용성이 없다고 판단하여 페이지 내에 구현했습니다.
- 추가로, 알림페이지의 경우 당장 지정해놓은 주소가 "/my/notifications" 인데 이러면 헤더 파일의 분기처리에서 depth가 2 이상으로 판단되어 뒤로가기 버튼만 있는 헤더로 적용이 됩니다. 피그마 바탕으로 보았을 때 뒤로가기 버튼과, 라우트네임인 Notifications가 필요하여 이에 따른 분기처리를 일단 추가해보았습니다. 최대한 다른 파일에 영향가지 않게 해두었으나 추후 회의에서 의논해보아야할 사항 같습니다.
- "/my/notificaitons"로 설정한 이유는 바텀바에서 가장 우측의 마이 아이콘이 활성화되어 있는 상태여야하는데, 이러려면 "/my" 로 시작하게 설정해두어서 맞추려는 의도였습니다. 추후 해당 설정에 관한 내용도 필요하다면 의논해보아야할 것 같습니다.

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] 코드 스타일을 eslint/prettier로 맞췄나요?
