### PR TITLE
feat: 개인 채팅 관련 로직 구현

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -33,6 +33,7 @@ import NotificationPage from "@/pages/Notification/NotificationPage";
 import NotificationDetailPage from "@/pages/Notification/NotificationDetailPage";
 import ChatPage from "@/pages/chat/ChatPage";
 import ChatDemoPage from "@/pages/chat/ChatDemoPage";
+import PrivateChatPage from "@/pages/chat/PrivateChatPage";
 import PretestArtistPage from "@/pages/pretest/artist/PretestArtistPage";
 import PretestSessionPage from "@/pages/pretest/session/PretestSessionPage";
 import PretestProfileCompletePage from "@/pages/pretest/profile/PretestProfileCompletePage";
@@ -304,6 +305,14 @@ const routes = [
         element: (
           <ProtectedRoute requireAuth={true}>
             <ChatPage />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: "/home/private-chat",
+        element: (
+          <ProtectedRoute requireAuth={true}>
+            <PrivateChatPage />
           </ProtectedRoute>
         ),
       },

--- a/src/features/setting/hooks/useAuth.ts
+++ b/src/features/setting/hooks/useAuth.ts
@@ -7,6 +7,7 @@ import { API_ENDPOINTS } from "@/constants";
 export const logout = () => {
   localStorage.removeItem("accessToken");
   localStorage.removeItem("refreshToken");
+  localStorage.removeItem("memberId");
 
   authStore.accessToken = null;
   authStore.refreshToken = null;

--- a/src/pages/chat/PrivateChatPage.tsx
+++ b/src/pages/chat/PrivateChatPage.tsx
@@ -75,7 +75,12 @@ const PrivateChatPage: React.FC = () => {
           chatName: room.chatName,
           imageUrl: room.imageUrl,
           memberInfo: room.memberInfo,
-          memberInfos: room.memberInfos,
+          memberInfos: room.memberInfos?.map(member => ({
+            memberId: member.memberId,
+            nickname: member.nickname,
+            profileImageUrl: member.profileImageUrl,
+            lastReadMessageId: member.lastReadMessageId || 0, // undefined인 경우 0으로 기본값 설정
+          })),
           unreadCount: room.unreadCount || 0,
           lastMessageAt: room.lastMessageAt,
           roomType: room.roomType,

--- a/src/pages/chat/PrivateChatPage.tsx
+++ b/src/pages/chat/PrivateChatPage.tsx
@@ -1,0 +1,333 @@
+import React, { useState, useEffect, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { usePrivateChat } from "./hooks/usePrivateChat";
+import ChatHeader from "./_components/ChatHeader";
+import ChatDateDivider from "./_components/ChatDateDivider";
+import ChatMessageList from "./_components/PrivateChatMessageList";
+import ChatInputBar from "./_components/ChatInputBar";
+import profile1Img from "@/assets/images/profile1.png";
+import type { ChatMessage as ChatMessageType, ChatRoomsResponse, ChatRoomInfo, MemberInfo } from "@/types/chat";
+
+interface ChatRoom {
+  roomId: number;
+  chatName: string;
+  imageUrl: string | null;
+  // 개인채팅의 경우 memberInfo (단수), 그룹채팅의 경우 memberInfos (복수)
+  memberInfo?: {
+    memberId: number;
+    nickname: string;
+    profileImageUrl: string | null;
+    lastReadMessageId: number; // API 응답과 일치하도록 수정
+  };
+  memberInfos?: Array<{
+    memberId: number;
+    nickname: string;
+    profileImageUrl: string | null;
+    lastReadMessageId: number; // API 응답과 일치하도록 수정
+  }>;
+  unreadCount: number;
+  lastMessageAt: string | null;
+  roomType: "PRIVATE" | "GROUP" | "BAND";
+}
+
+const PrivateChatPage: React.FC = () => {
+  const navigate = useNavigate();
+  const {
+    currentRoomId,
+    messages,
+    chatRooms,
+    isConnected,
+    isLoading,
+    enterChatRoom,
+    sendMessage,
+    leaveChatRoom,
+    shouldShowReadIndicator,
+  } = usePrivateChat();
+
+  const [selectedReceiverId, setSelectedReceiverId] = useState<number | null>(null);
+  const [showActions, setShowActions] = useState(false);
+  const [currentChatRoom, setCurrentChatRoom] = useState<ChatRoom | null>(null);
+
+  // 개인채팅방만 필터링 (실제 API 응답 구조에 맞춤) - useMemo로 메모이제이션
+  const privateChatRooms = useMemo(() => {
+    return ((chatRooms as ChatRoomsResponse)?.result?.chatRoomInfos || [])
+      .filter((room: ChatRoomInfo) => room.roomType === "PRIVATE")
+      .map((room: ChatRoomInfo) => ({
+        roomId: room.roomId,
+        chatName: room.chatName,
+        imageUrl: room.imageUrl,
+        memberInfo: room.memberInfo, // 개인채팅은 memberInfo 사용
+        memberInfos: room.memberInfos,
+        unreadCount: room.unreadCount || 0,
+        lastMessageAt: room.lastMessageAt,
+        roomType: "PRIVATE" as const,
+      }));
+  }, [chatRooms]);
+
+  // 현재 채팅방 정보 찾기
+  useEffect(() => {
+    if (currentRoomId && privateChatRooms.length > 0) {
+      const room = privateChatRooms.find((r: ChatRoomInfo) => r.roomId === currentRoomId);
+      if (room) {
+        // ChatRoomInfo를 ChatRoom으로 변환
+        const convertedRoom: ChatRoom = {
+          roomId: room.roomId,
+          chatName: room.chatName,
+          imageUrl: room.imageUrl,
+          memberInfo: room.memberInfo,
+          memberInfos: room.memberInfos,
+          unreadCount: room.unreadCount || 0,
+          lastMessageAt: room.lastMessageAt,
+          roomType: room.roomType,
+        };
+        setCurrentChatRoom(convertedRoom);
+      } else {
+        setCurrentChatRoom(null);
+      }
+    }
+  }, [currentRoomId, privateChatRooms]);
+
+  // ChatMessageList용 메시지 형식으로 변환
+  const convertedMessages: ChatMessageType[] = messages.map((msg) => {
+    const currentMemberId = parseInt(localStorage.getItem("memberId") || "0");
+    const isMyMessage = msg.senderId === currentMemberId;
+    const showReadIndicator = shouldShowReadIndicator(msg);
+    
+    console.log("🔄 메시지 변환:", {
+      messageId: msg.messageId,
+      senderId: msg.senderId,
+      isMyMessage,
+      showReadIndicator,
+      isRead: msg.isRead,
+      readBy: msg.readBy
+    });
+    
+    return {
+      id: msg.messageId.toString(),
+      type: isMyMessage ? "me" : "other",
+      name: msg.senderName,
+      avatar: profile1Img, // 기본 이미지 사용
+      text: msg.content,
+      time: new Date(msg.timestamp).toLocaleTimeString("ko-KR", {
+        hour: "2-digit",
+        minute: "2-digit",
+      }),
+      // 읽음 상태에 따라 "1" 표시 제어
+      showReadIndicator,
+    };
+  });
+
+  const handleSendMessage = (text: string) => {
+    console.log("🔘 전송 버튼 클릭됨");
+    console.log("📝 입력된 메시지:", text);
+    console.log("👤 선택된 수신자 ID:", selectedReceiverId);
+    console.log("🔗 WebSocket 연결 상태:", isConnected);
+    console.log("🏠 현재 채팅방 ID:", currentRoomId);
+
+    if (!text.trim()) {
+      console.warn("⚠️ 메시지가 비어있음");
+      return;
+    }
+
+    if (!selectedReceiverId) {
+      console.error("❌ 수신자 ID가 설정되지 않았습니다. 채팅방을 다시 선택해주세요.");
+      alert("채팅방을 다시 선택해주세요.");
+      return;
+    }
+
+    if (!isConnected) {
+      console.warn("⚠️ WebSocket이 연결되지 않음");
+      alert("연결 상태를 확인해주세요.");
+      return;
+    }
+
+    console.log("📤 메시지 전송 시도...");
+    sendMessage(text, selectedReceiverId);
+    console.log("✅ 메시지 전송 완료 (UI 업데이트)");
+  };
+
+  const handleEnterRoom = async (room: ChatRoomInfo) => {
+    if (!room || !room.roomId) {
+      console.error("❌ 유효하지 않은 채팅방:", room);
+      return;
+    }
+    
+    console.log("🎯 채팅방 입장 시도:", room.roomId);
+    await enterChatRoom(room.roomId);
+    
+    // 상대방 ID 설정 (개인채팅이므로 상대방은 1명)
+    const currentMemberId = parseInt(localStorage.getItem("memberId") || "0");
+    console.log("🔍 현재 사용자 ID:", currentMemberId);
+    
+    if (room.roomType === "PRIVATE") {
+      // 개인채팅의 경우 memberInfo 사용
+      console.log("👥 개인채팅 멤버 정보:", room.memberInfo);
+      
+      if (!room.memberInfo) {
+        console.error("❌ 개인채팅 멤버 정보가 없습니다. 채팅방 정보:", room);
+        console.error("❌ 현재 사용자 ID:", currentMemberId);
+        return;
+      }
+      
+      // 개인채팅에서는 memberInfo가 상대방 정보
+      setSelectedReceiverId(room.memberInfo.memberId);
+      console.log("✅ 상대방 ID 설정 완료:", room.memberInfo.memberId);
+    } else {
+      // 그룹채팅의 경우 memberInfos 사용
+      console.log("👥 그룹채팅 멤버 정보:", room.memberInfos);
+      
+      if (!room.memberInfos || room.memberInfos.length === 0) {
+        console.error("❌ 그룹채팅 멤버 정보가 없습니다. 채팅방 정보:", room);
+        console.error("❌ 현재 사용자 ID:", currentMemberId);
+        return;
+      }
+      
+      const otherMember = room.memberInfos.find((member: MemberInfo) => member.memberId !== currentMemberId);
+      console.log("🎯 찾은 상대방:", otherMember);
+      
+      if (otherMember?.memberId) {
+        setSelectedReceiverId(otherMember.memberId);
+        console.log("✅ 상대방 ID 설정 완료:", otherMember.memberId);
+      } else {
+        console.error("❌ 상대방을 찾을 수 없음. 채팅방 정보:", room);
+        console.error("❌ 현재 사용자 ID:", currentMemberId);
+        console.error("❌ 채팅방 멤버:", room.memberInfos);
+        
+        // memberId가 유효하지 않으면 경고만 표시하고 수신자 ID 설정하지 않음
+        if (!currentMemberId || currentMemberId === 0) {
+          console.error("❌ 현재 사용자 ID가 유효하지 않아 수신자 ID를 설정할 수 없습니다.");
+          return;
+        }
+        
+        // 하드코딩된 값 제거 - 상대방을 찾을 수 없으면 메시지 전송 불가
+        console.error("❌ 상대방을 찾을 수 없어 메시지 전송이 불가능합니다.");
+        setSelectedReceiverId(null);
+      }
+    }
+  };
+
+  const handleBack = () => {
+    if (currentRoomId) {
+      leaveChatRoom();
+    } else {
+      navigate(-1);
+    }
+  };
+
+  const handleLoadMore = () => {
+    // 무한 스크롤 로직 (필요시 구현)
+    console.log("더 많은 메시지 로드");
+  };
+
+  const formatTime = (timestamp: string): string => {
+    try {
+      const date = new Date(timestamp);
+      if (isNaN(date.getTime())) {
+        return "00:00";
+      }
+      return date.toLocaleTimeString("ko-KR", {
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+    } catch (error) {
+      console.error("시간 포맷 에러:", error);
+      return "00:00";
+    }
+  };
+
+  // 채팅방이 선택되지 않은 경우 채팅방 목록 표시
+  if (!currentRoomId) {
+    return (
+      <div className="min-h-screen w-full flex flex-col bg-[#121212]">
+        <div className="w-full bg-[#181818] pb-6">
+          <div className="flex items-center justify-between px-6 pt-8 pb-5 h-32">
+            <button
+              className="flex items-center justify-center w-16 h-16 rounded-full hover:bg-white/10 transition-colors"
+              onClick={() => navigate(-1)}
+            >
+              <svg width="32" height="32" fill="none" viewBox="0 0 24 24" className="text-white">
+                <path d="M19 12H5M12 19l-7-7 7-7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+              </svg>
+            </button>
+            <div className="flex flex-col items-center">
+              <span className="text-lg font-semibold text-white">개인채팅</span>
+            </div>
+            <div className="w-16"></div>
+          </div>
+        </div>
+
+        <div className="flex-1 flex flex-col bg-[#F3F3F3] rounded-t-[40px] overflow-hidden">
+          <div className="flex-1 overflow-y-auto px-6 py-4">
+            <div className="space-y-4">
+              {privateChatRooms.map((room) => (
+                <div
+                  key={room.roomId}
+                  className="flex items-center p-4 bg-white rounded-lg shadow-sm cursor-pointer hover:bg-gray-50"
+                  onClick={() => handleEnterRoom(room)}
+                >
+                  <div className="w-12 h-12 bg-gray-300 rounded-full mr-4 flex items-center justify-center">
+                    <span className="text-gray-600 font-semibold">
+                      {room.chatName.charAt(0)}
+                    </span>
+                  </div>
+                  <div className="flex-1">
+                    <h3 className="font-semibold text-gray-900">{room.chatName}</h3>
+                    <p className="text-sm text-gray-500">
+                      {room.lastMessageAt ? formatTime(room.lastMessageAt) : "새로운 채팅방"}
+                    </p>
+                  </div>
+                  {room.unreadCount > 0 && (
+                    <div className="bg-red-500 text-white text-xs rounded-full w-6 h-6 flex items-center justify-center">
+                      {room.unreadCount}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen w-full flex flex-col bg-[#121212]">
+      <ChatHeader
+        bandName={currentChatRoom?.chatName || "개인채팅"}
+        bandAvatar={currentChatRoom?.imageUrl || profile1Img}
+        onBack={handleBack}
+        onReport={() => console.log("신고하기")}
+        onBlock={() => console.log("차단하기")}
+        onLeave={() => {
+          leaveChatRoom();
+          navigate(-1);
+        }}
+      />
+
+      <div className="flex-1 flex flex-col bg-[#F3F3F3] rounded-t-[40px] overflow-hidden relative">
+        <ChatDateDivider />
+        <ChatMessageList
+          messages={convertedMessages}
+          onLoadMore={handleLoadMore}
+          isLoading={isLoading}
+        />
+        {/* 하단 여백 - 입력창 상태에 따라 동적 조정 */}
+        <div
+          className={`transition-all duration-300 ease-in-out ${
+            showActions ? "h-32" : "h-4"
+          }`}
+        ></div>
+      </div>
+
+      {/* ChatInputBar를 고정 위치로 변경 */}
+      <div className="fixed bottom-0 left-0 right-0 z-10">
+        <ChatInputBar
+          onSendMessage={handleSendMessage}
+          onShowActionsChange={setShowActions}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default PrivateChatPage;

--- a/src/pages/chat/_components/PrivateChatMessageList.tsx
+++ b/src/pages/chat/_components/PrivateChatMessageList.tsx
@@ -1,0 +1,84 @@
+import React, { useState, useEffect, useRef } from "react";
+import ChatMessageItem from "./ChatMessageItem";
+import type { ChatMessage } from "@/types/chat";
+
+interface ChatMessageListProps {
+  messages?: readonly ChatMessage[];
+  onLoadMore?: () => void;
+  isLoading?: boolean;
+}
+
+export default function PrivateChatMessageList({
+  messages = [],
+  onLoadMore,
+  isLoading = false,
+}: ChatMessageListProps) {
+  const [playingAudioId, setPlayingAudioId] = useState<string | null>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Auto scroll to bottom when new messages arrive
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  const handleAudioPlay = (messageId: string) => {
+    // Stop currently playing audio
+    if (playingAudioId && playingAudioId !== messageId) {
+      setPlayingAudioId(null);
+    }
+
+    // Toggle current audio
+    setPlayingAudioId(playingAudioId === messageId ? null : messageId);
+  };
+
+  const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
+    const { scrollTop } = e.currentTarget;
+    if (scrollTop === 0 && onLoadMore && !isLoading) {
+      onLoadMore();
+    }
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className="flex-1 overflow-y-auto px-0 py-4"
+      onScroll={handleScroll}
+    >
+      {isLoading && (
+        <div className="flex justify-center py-4">
+          <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-gray-400"></div>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {messages.map((message) => {
+          const unreadCount = message.showReadIndicator ? 1 : undefined;
+          
+          return (
+            <ChatMessageItem
+              key={message.id}
+              type={message.type}
+              name={message.name}
+              avatar={message.avatar}
+              text={message.text}
+              audio={
+                message.audio
+                  ? {
+                      ...message.audio,
+                      isPlaying: playingAudioId === message.id,
+                      onPlay: () => handleAudioPlay(message.id),
+                    }
+                  : undefined
+              }
+              time={message.time}
+              unreadCount={unreadCount}
+            />
+          );
+        })}
+      </div>
+
+      <div ref={messagesEndRef} className="pb-16" />
+    </div>
+  );
+}

--- a/src/pages/chat/hooks/useChat.ts
+++ b/src/pages/chat/hooks/useChat.ts
@@ -61,7 +61,7 @@ export const useChat = () => {
         const response = await getChatMessages(roomId, cursor);
 
         // API 응답을 ChatMessage 형식으로 변환
-        const chatMessages: ChatMessage[] = response.messages.map((msg) => ({
+        const chatMessages: ChatMessage[] = response.result.messages.map((msg) => ({
           id: msg.messageId.toString(),
           type: "other", // 기본값, 실제로는 현재 사용자 ID와 비교해야 함
           name: msg.senderName,
@@ -83,8 +83,8 @@ export const useChat = () => {
           chatActions.setMessages(chatMessages);
         }
 
-        setHasMoreMessages(response.hasNext);
-        setLastMessageId(response.lastMessageId);
+        setHasMoreMessages(response.result.hasNext);
+        setLastMessageId(response.result.lastMessageId);
 
         console.log(`${chatMessages.length}개의 메시지 로드 완료`);
       } catch (error) {

--- a/src/pages/chat/hooks/usePrivateChat.ts
+++ b/src/pages/chat/hooks/usePrivateChat.ts
@@ -1,0 +1,559 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { webSocketService } from "@/services/WebSocketService";
+import { getChatRooms, getPriChatMessages } from "@/store/chatApi";
+import type { WebSocketMessage } from "@/types/chat";
+
+interface ChatMessage {
+  messageId: number;
+  senderId: number;
+  senderName: string;
+  content: string;
+  timestamp: string;
+  roomId: number;
+  isRead?: boolean; // 읽음 상태
+  readBy?: number[]; // 누가 읽었는지 (memberId 배열)
+}
+
+// 읽음 처리 관련 타입
+interface ParticipantInfo {
+  memberId: number;
+  nickname: string;
+  imageUrl: string | null;
+  lastReadMessageId: number;
+}
+
+interface ReadMessage {
+  memberId: number;
+  nickname: string;
+  roomId: number;
+  messageId: number;
+}
+
+
+
+interface SendMessageRequest {
+  roomId: number;
+  receiverId: number;
+  content: string;
+}
+
+export const usePrivateChat = () => {
+  const queryClient = useQueryClient();
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [currentRoomId, setCurrentRoomId] = useState<number | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const messageEndRef = useRef<HTMLDivElement>(null);
+  
+  // 읽음 처리 관련 상태
+  const [participants, setParticipants] = useState<ParticipantInfo[]>([]);
+  const [lastSentReadMessageId, setLastSentReadMessageId] = useState<number>(0);
+
+  // 채팅방 목록 조회
+  const { data: chatRooms, isLoading: roomsLoading } = useQuery({
+    queryKey: ["chatRooms"],
+    queryFn: getChatRooms,
+  });
+
+  // WebSocket 연결 상태 감지
+  useEffect(() => {
+    const checkConnection = () => {
+      const connected = webSocketService.isConnected();
+      if (connected !== isConnected) {
+        console.log("🔌 WebSocket 연결 상태 변경:", isConnected, "→", connected);
+        setIsConnected(connected);
+      }
+    };
+
+    checkConnection();
+    const interval = setInterval(checkConnection, 1000);
+    return () => clearInterval(interval);
+  }, [isConnected]);
+
+  // 채팅방 입장
+  const enterChatRoom = useCallback(async (roomId: number) => {
+    console.log("🎯 채팅방 입장:", roomId);
+    setIsLoading(true);
+    
+    try {
+      // WebSocket 연결 상태 확인 (이미 연결되어 있으면 연결 시도하지 않음)
+      if (!webSocketService.isConnected()) {
+        console.log("🔌 WebSocket 연결 시도...");
+        await webSocketService.connect();
+      } else {
+        console.log("✅ WebSocket 이미 연결됨");
+      }
+
+      // 이전 채팅방 구독 해제
+      if (currentRoomId) {
+        webSocketService.unsubscribeFromRoom(currentRoomId.toString());
+      }
+
+      // 새 채팅방 구독
+      webSocketService.subscribeToPrivateRoom(roomId.toString(), (message: WebSocketMessage) => {
+        console.log("💬 개인채팅 메시지 수신 (원본):", message);
+        
+        // WebSocket 메시지 구조 확인 및 파싱
+        let parsedMessage: WebSocketMessage;
+        
+        // 메시지가 {type: 'MESSAGE', data: {...}} 형태인지 확인
+        const messageWithType = message as WebSocketMessage & { type?: string; data?: WebSocketMessage | ReadMessage };
+        if (messageWithType.type === "MESSAGE" && messageWithType.data) {
+          parsedMessage = messageWithType.data as WebSocketMessage;
+          console.log("📋 파싱된 메시지:", parsedMessage);
+        } else if (messageWithType.type === "READ" && messageWithType.data) {
+          // 읽음 상태 메시지 처리
+          const readMessage = messageWithType.data as ReadMessage;
+          handleReadMessage(readMessage);
+          return;
+        } else if (message.messageId && message.content) {
+          // 직접 WebSocketMessage 형태인 경우
+          parsedMessage = message;
+          console.log("📋 직접 메시지:", parsedMessage);
+        } else {
+          console.warn("⚠️ 알 수 없는 메시지 구조:", message);
+          return;
+        }
+        
+        // 메시지 데이터 검증
+        if (!parsedMessage || !parsedMessage.content) {
+          console.warn("⚠️ 유효하지 않은 메시지:", parsedMessage);
+          return;
+        }
+
+        console.log("📋 메시지 데이터:", parsedMessage);
+        
+        // 현재 사용자 ID 확인
+        const currentMemberId = parseInt(localStorage.getItem("memberId") || "0");
+        console.log("🔍 localStorage memberId:", localStorage.getItem("memberId"), "파싱된 ID:", currentMemberId, "메시지 발신자 ID:", parsedMessage.senderId);
+        
+        // 본인이 보낸 메시지인 경우 (서버 응답)
+        if (parsedMessage.senderId === currentMemberId) {
+          console.log("🔄 본인이 보낸 메시지 감지 (서버 응답)");
+          
+          // 낙관적 업데이트된 메시지를 실제 메시지로 교체
+          setMessages(prev => {
+            const updatedMessages = prev.map(msg => {
+              // 임시 ID로 생성된 낙관적 메시지를 찾아서 실제 메시지로 교체
+              if (msg.senderId === currentMemberId && 
+                  msg.content === parsedMessage.content && 
+                  isTemporaryId(msg.messageId)) { // 임시 ID인지 확인
+                console.log("🔄 낙관적 메시지를 실제 메시지로 교체:", msg.messageId, "→", parsedMessage.messageId);
+                return {
+                  ...msg,
+                  messageId: parsedMessage.messageId || msg.messageId,
+                  senderName: parsedMessage.senderName || msg.senderName,
+                  timestamp: parsedMessage.timestamp || msg.timestamp,
+                };
+              }
+              return msg;
+            });
+            return updatedMessages;
+          });
+          return;
+        }
+        
+        // 상대방이 보낸 메시지인 경우
+        // timestamp에 시간대 표시자 추가 (Z가 없으면 UTC로 가정)
+        let normalizedTimestamp = parsedMessage.timestamp;
+        if (normalizedTimestamp && !normalizedTimestamp.endsWith("Z")) {
+          normalizedTimestamp = normalizedTimestamp + "Z";
+        }
+        
+        const newMessage: ChatMessage = {
+          messageId: parsedMessage.messageId || Date.now(),
+          senderId: parsedMessage.senderId || 0,
+          senderName: parsedMessage.senderName || "알 수 없음",
+          content: parsedMessage.content || "",
+          timestamp: normalizedTimestamp || new Date().toISOString(),
+          roomId: parsedMessage.roomId || roomId,
+          isRead: false, // 새 메시지는 기본적으로 안읽음
+          readBy: [], // 아직 아무도 읽지 않음
+        };
+
+        console.log("✅ 새 메시지 생성:", newMessage);
+        setMessages(prev => {
+          const updatedMessages = [...prev, newMessage];
+          console.log("📝 메시지 배열 업데이트:", updatedMessages.length, "개 메시지");
+          return updatedMessages;
+        });
+        
+        // 메시지 수신 시 읽음 상태 자동 전송
+        if (newMessage.senderId !== currentMemberId) {
+          // 상대방 메시지를 받았을 때만 읽음 상태 전송
+          setTimeout(() => {
+            sendReadStatus(newMessage.messageId, newMessage.roomId);
+          }, 1000); // 1초 후 읽음 상태 전송
+          
+          // 즉시 로컬에서 읽음 상태 업데이트
+          const currentMemberId = parseInt(localStorage.getItem("memberId") || "0");
+          setMessages(prev => 
+            prev.map(msg => 
+              msg.messageId === newMessage.messageId
+                ? {
+                    ...msg,
+                    isRead: true,
+                    readBy: [...(msg.readBy || []), currentMemberId]
+                  }
+                : msg
+            )
+          );
+        }
+        
+        // 스크롤을 맨 아래로
+        setTimeout(() => {
+          messageEndRef.current?.scrollIntoView({ behavior: "smooth" });
+        }, 100);
+      });
+
+      // 채팅방 ID 즉시 설정 (메시지 로드 전에)
+      setCurrentRoomId(roomId);
+      console.log("🎯 채팅방 ID 설정:", roomId);
+      
+      // 채팅방 메시지 히스토리 로드
+      const response = await getPriChatMessages(roomId.toString());
+      console.log("📋 API 응답:", response);
+      console.log("📋 API 응답 구조:", {
+        hasResponse: !!response,
+        hasMessages: !!response?.result?.messages,
+        messagesLength: response?.result?.messages?.length,
+        responseKeys: response ? Object.keys(response) : []
+      });
+      
+      // 안전한 체크: messages가 존재하는지 확인 (API 응답 구조에 맞춤)
+      if (!response?.result?.messages) {
+        console.warn("⚠️ 메시지 데이터가 없습니다:", response);
+        setMessages([]);
+        return;
+      }
+      
+      // API에서 받은 메시지를 올바른 순서로 정렬 (오래된 메시지가 위에, 최신 메시지가 아래에)
+      const chatMessages: ChatMessage[] = response.result.messages
+        .slice() // 원본 배열 복사 (reverse는 원본을 변경하므로)
+        .reverse() // 배열을 역순으로 정렬하여 오래된 메시지가 앞에 오도록
+        .map((msg) => {
+          // timestamp에 시간대 표시자 추가 (Z가 없으면 UTC로 가정)
+          let normalizedTimestamp = msg.timestamp;
+          if (normalizedTimestamp && !normalizedTimestamp.endsWith("Z")) {
+            normalizedTimestamp = normalizedTimestamp + "Z";
+          }
+          
+          return {
+            messageId: msg.messageId,
+            senderId: msg.senderId,
+            senderName: msg.senderName,
+            content: msg.content,
+            timestamp: normalizedTimestamp,
+            roomId: roomId, // API 응답에 roomId가 없으므로 현재 roomId 사용
+            isRead: false, // 기존 메시지는 기본적으로 안읽음
+            readBy: [], // 아직 아무도 읽지 않음
+          };
+        });
+
+      console.log("📝 로드된 메시지 개수:", chatMessages.length);
+      console.log("📝 첫 번째 메시지 (가장 오래된):", chatMessages[0]);
+      console.log("📝 마지막 메시지 (가장 최신):", chatMessages[chatMessages.length - 1]);
+      console.log("📝 메시지 정렬 확인 - 첫 번째 timestamp:", chatMessages[0]?.timestamp);
+      console.log("📝 메시지 정렬 확인 - 마지막 timestamp:", chatMessages[chatMessages.length - 1]?.timestamp);
+      
+      setMessages(chatMessages);
+      setCurrentRoomId(roomId);
+      
+      // 참가자 정보 초기화 (임시로 현재 사용자 정보 설정)
+      const currentMemberId = parseInt(localStorage.getItem("memberId") || "0");
+      const initialParticipants: ParticipantInfo[] = [
+        {
+          memberId: currentMemberId,
+          nickname: "나",
+          imageUrl: null,
+          lastReadMessageId: 0
+        }
+      ];
+      setParticipants(initialParticipants);
+      
+      console.log("✅ 채팅방 입장 완료:", {
+        roomId,
+        isConnected,
+        webSocketConnected: webSocketService.isConnected(),
+        messagesCount: chatMessages.length,
+        participants: initialParticipants
+      });
+      
+      // 스크롤을 맨 아래로
+      setTimeout(() => {
+        messageEndRef.current?.scrollIntoView({ behavior: "smooth" });
+      }, 100);
+    } catch (error) {
+      console.error("❌ 채팅방 입장 실패:", error);
+      // WebSocket 연결 실패 시 사용자에게 알림
+      if (error instanceof Error && error.message?.includes("WebSocket")) {
+        alert("연결에 실패했습니다. 다시 시도해주세요.");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [currentRoomId]);
+
+  // 채팅방 퇴장
+  const leaveChatRoom = useCallback(() => {
+    if (currentRoomId) {
+      webSocketService.unsubscribeFromRoom(currentRoomId.toString());
+      setCurrentRoomId(null);
+      setMessages([]);
+      console.log("👋 채팅방 퇴장:", currentRoomId);
+    }
+  }, [currentRoomId]);
+
+  // 메시지 전송
+  const sendMessageMutation = useMutation({
+    mutationFn: async ({ roomId, receiverId, content }: SendMessageRequest) => {
+      console.log("🔄 sendMessageMutation.mutationFn 실행");
+      console.log("📋 전송 파라미터:", { roomId, receiverId, content });
+      
+      try {
+        webSocketService.sendMessage(roomId.toString(), content, "PRIVATE", receiverId);
+        console.log("✅ webSocketService.sendMessage 호출 완료");
+        return { roomId, content };
+      } catch (error) {
+        console.error("❌ webSocketService.sendMessage 에러:", error);
+        throw error;
+      }
+    },
+    onSuccess: (data, variables) => {
+      console.log("🎉 sendMessageMutation.onSuccess 실행");
+      console.log("📤 전송된 메시지:", variables);
+      
+      // 낙관적 업데이트: 발신자가 자신의 메시지를 즉시 볼 수 있도록
+      const currentMemberId = parseInt(localStorage.getItem("memberId") || "0");
+      const temporaryId = Date.now();
+      console.log("✨ 낙관적 업데이트 - 임시 ID 생성:", temporaryId);
+      
+      const optimisticMessage: ChatMessage = {
+        messageId: temporaryId, // 임시 ID (나중에 서버 ID로 교체됨)
+        senderId: currentMemberId,
+        senderName: "나", // 임시 이름
+        content: variables.content,
+        timestamp: new Date().toISOString(),
+        roomId: variables.roomId,
+        isRead: true, // 본인이 보낸 메시지는 자동으로 읽음 처리
+        readBy: [currentMemberId], // 본인이 읽음
+      };
+      
+      console.log("✨ 낙관적 업데이트 메시지:", optimisticMessage);
+      setMessages(prev => {
+        const updatedMessages = [...prev, optimisticMessage];
+        console.log("📝 낙관적 업데이트 완료:", updatedMessages.length, "개 메시지");
+        return updatedMessages;
+      });
+      
+      // 메시지 전송 후 채팅방 목록 업데이트
+      queryClient.invalidateQueries({ queryKey: ["chatRooms"] });
+    },
+    onError: (error) => {
+      console.error("❌ sendMessageMutation.onError:", error);
+    },
+  });
+
+  // 읽음 상태 전송 함수
+  const sendReadStatus = useCallback((messageId: number, roomId?: number) => {
+    // roomId가 제공되지 않으면 currentRoomId 사용, 둘 다 없으면 실패
+    const targetRoomId = roomId || currentRoomId;
+    const webSocketConnected = webSocketService.isConnected();
+    
+    console.log("🔍 읽음 상태 전송 시도:", {
+      messageId,
+      targetRoomId,
+      currentRoomId,
+      isConnected,
+      webSocketConnected
+    });
+    
+    // 임시 ID인 경우 전송하지 않음
+    if (isTemporaryId(messageId)) {
+      console.log("🔄 임시 ID 메시지 - 읽음 상태 전송 제외:", messageId);
+      return;
+    }
+    
+    if (!targetRoomId || !webSocketConnected) {
+      console.warn("⚠️ 읽음 상태 전송 실패: 채팅방이 없거나 연결되지 않음", {
+        targetRoomId,
+        currentRoomId,
+        isConnected,
+        webSocketConnected
+      });
+      return;
+    }
+
+    // 중복 전송 방지
+    if (messageId <= lastSentReadMessageId) {
+      console.log("🔄 중복 전송 방지:", messageId, "<==", lastSentReadMessageId);
+      return;
+    }
+
+    try {
+      // WebSocket으로 읽음 상태 전송
+      webSocketService.sendReadStatus(targetRoomId.toString(), messageId);
+      setLastSentReadMessageId(messageId);
+      console.log("📖 읽음 상태 전송 성공:", messageId, "roomId:", targetRoomId);
+    } catch (error) {
+      console.error("❌ 읽음 상태 전송 실패:", error);
+    }
+  }, [currentRoomId, isConnected, lastSentReadMessageId]);
+
+  // 읽음 상태 수신 처리 함수
+  const handleReadMessage = useCallback((readMessage: ReadMessage) => {
+    console.log("📖 읽음 상태 수신:", readMessage);
+    
+    // 참가자 정보 업데이트
+    setParticipants(prev => {
+      const updated = prev.map(participant => 
+        participant.memberId === readMessage.memberId
+          ? { ...participant, lastReadMessageId: readMessage.messageId }
+          : participant
+      );
+      
+      // 참가자가 없으면 추가
+      if (!prev.find(p => p.memberId === readMessage.memberId)) {
+        updated.push({
+          memberId: readMessage.memberId,
+          nickname: readMessage.nickname,
+          imageUrl: null,
+          lastReadMessageId: readMessage.messageId
+        });
+      }
+      
+      console.log("📖 참가자 정보 업데이트:", updated);
+      return updated;
+    });
+    
+    // 메시지 읽음 상태 업데이트
+    setMessages(prev => 
+      prev.map(message => {
+        if (message.messageId <= readMessage.messageId) {
+          // 해당 메시지까지 읽음 처리
+          const currentReadBy = message.readBy || [];
+          const updatedReadBy = currentReadBy.includes(readMessage.memberId) 
+            ? currentReadBy 
+            : [...currentReadBy, readMessage.memberId];
+          
+          return {
+            ...message,
+            isRead: true,
+            readBy: updatedReadBy
+          };
+        }
+        return message;
+      })
+    );
+    
+    console.log("📖 메시지 읽음 상태 업데이트 완료:", readMessage.messageId);
+  }, []);
+
+
+
+  // 임시 ID 식별 함수 (Date.now()로 생성된 큰 숫자)
+  const isTemporaryId = useCallback((messageId: number) => {
+    return messageId > 1000000000000; // 13자리 이상의 숫자는 임시 ID
+  }, []);
+
+  // 안읽은 메시지 수 계산 함수
+  const getUnreadCount = useCallback(() => {
+    if (messages.length === 0) return 0;
+    
+    const currentMemberId = parseInt(localStorage.getItem("memberId") || "0");
+    const currentParticipant = participants.find(p => p.memberId === currentMemberId);
+    
+    if (!currentParticipant) return 0;
+    
+    // 임시 ID를 제외하고 실제 서버 ID만 사용
+    const serverMessageIds = messages
+      .filter(m => !isTemporaryId(m.messageId))
+      .map(m => m.messageId);
+    
+    if (serverMessageIds.length === 0) return 0;
+    
+    const lastMessageId = Math.max(...serverMessageIds);
+    return Math.max(0, lastMessageId - currentParticipant.lastReadMessageId);
+  }, [messages, participants, isTemporaryId]);
+
+  // 메시지 읽음 상태 확인 함수
+  const isMessageRead = useCallback((message: ChatMessage) => {
+    const currentMemberId = parseInt(localStorage.getItem("memberId") || "0");
+    
+    // 본인이 보낸 메시지는 항상 읽음
+    if (message.senderId === currentMemberId) {
+      return true;
+    }
+    
+    // 다른 사람이 보낸 메시지는 readBy 배열에 현재 사용자가 있으면 읽음
+    return message.readBy?.includes(currentMemberId) || false;
+  }, []);
+
+  // 메시지별 읽음 표시 여부 확인 함수
+  const shouldShowReadIndicator = useCallback((message: ChatMessage) => {
+    const currentMemberId = parseInt(localStorage.getItem("memberId") || "0");
+    
+    // 임시 ID인 경우 읽음 표시하지 않음 (서버 응답 대기 중)
+    if (isTemporaryId(message.messageId)) {
+      console.log("🔄 임시 ID 메시지 - 읽음 표시 제외:", message.messageId);
+      return false;
+    }
+    
+    console.log("🔍 shouldShowReadIndicator 체크:", {
+      messageId: message.messageId,
+      senderId: message.senderId,
+      currentMemberId,
+      isRead: message.isRead,
+      readBy: message.readBy,
+      participants: participants.map(p => ({ memberId: p.memberId, lastReadMessageId: p.lastReadMessageId }))
+    });
+    
+    // 본인이 보낸 메시지는 상대방이 읽었는지 확인
+    if (message.senderId === currentMemberId) {
+      // 상대방이 읽었으면 "1" 표시하지 않음
+      const otherParticipants = participants.filter(p => p.memberId !== currentMemberId);
+      const shouldShow = otherParticipants.some(p => p.lastReadMessageId < message.messageId);
+      console.log("📤 본인 메시지 읽음 표시:", shouldShow);
+      return shouldShow;
+    }
+    
+    // 다른 사람이 보낸 메시지는 내가 읽지 않았으면 "1" 표시
+    const isRead = isMessageRead(message);
+    const shouldShow = !isRead;
+    console.log("📥 상대방 메시지 읽음 표시:", shouldShow, "isRead:", isRead);
+    return shouldShow;
+  }, [participants, isMessageRead, isTemporaryId]);
+
+  // 메시지 전송 함수
+  const sendMessage = useCallback((content: string, receiverId: number) => {
+    if (!currentRoomId) {
+      console.error("❌ 현재 채팅방이 없습니다.");
+      return;
+    }
+
+    sendMessageMutation.mutate({
+      roomId: currentRoomId,
+      receiverId,
+      content,
+    });
+  }, [currentRoomId, sendMessageMutation]);
+
+  return {
+    currentRoomId,
+    messages,
+    chatRooms,
+    isConnected,
+    isLoading: isLoading || roomsLoading,
+    enterChatRoom,
+    sendMessage,
+    leaveChatRoom,
+    messageEndRef,
+    // 읽음 처리 관련 함수들
+    sendReadStatus,
+    getUnreadCount,
+    participants,
+    isMessageRead,
+    shouldShowReadIndicator,
+  };
+};

--- a/src/services/WebSocketService.ts
+++ b/src/services/WebSocketService.ts
@@ -359,8 +359,30 @@ class WebSocketService {
     this.stompClient.publish({
       destination,
       body: JSON.stringify(message),
+      headers: {
+        "content-type": "application/json;charset=UTF-8"
+      }
     });
     console.log("메시지 전송:", message);
+  }
+
+  // 읽음 상태 전송 함수
+  sendReadStatus(roomId: string, messageId: number): void {
+    if (!this.stompClient || !this.stompClient.connected) {
+      console.error("WebSocket이 연결되지 않았습니다.");
+      return;
+    }
+
+    const destination = `/app/chat/private.lastRead/${roomId}`;
+    
+    this.stompClient.publish({
+      destination,
+      body: messageId.toString(),
+      headers: {
+        "content-type": "text/plain;charset=UTF-8"
+      }
+    });
+    console.log("읽음 상태 전송:", { roomId, messageId });
   }
 
   isConnected(): boolean {

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -6,10 +6,12 @@ import { API_ENDPOINTS } from "@/constants";
 export const login = async (data: { email: string; password: string }) => {
   try {
     const res = await API.post(API_ENDPOINTS.AUTH.LOGIN, data);
-    const { accessToken, refreshToken } = res.data;
-
+    // const { accessToken, refreshToken } = res.data;
+    const { accessToken, refreshToken, memberId } = res.data;
+    
     localStorage.setItem("accessToken", accessToken);
     localStorage.setItem("refreshToken", refreshToken);
+    localStorage.setItem("memberId", memberId.toString());
 
     authStore.accessToken = accessToken;
     authStore.refreshToken = refreshToken;

--- a/src/store/chatApi.ts
+++ b/src/store/chatApi.ts
@@ -93,6 +93,23 @@ export const getChatMessages = async (
   return response.data;
 };
 
+// 채팅 메시지 조회 (새로운 API 스펙 - 무한 스크롤)
+export const getPriChatMessages = async (
+  roomId: string,
+  cursor?: number,
+  limit: number = 20
+): Promise<MessagesResponse> => {
+  const params: Record<string, number> = { limit };
+  if (cursor !== undefined) {
+    params.cursor = cursor;
+  }
+
+  const response = await API.get(
+    API_ENDPOINTS.CHAT.MESSAGES(roomId, cursor || 0, limit)
+  );
+  return response.data;
+};
+
 // 채팅방 참가자 정보 조회 (새로운 API)
 export const getChatRoomMembers = async (
   roomId: string

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -13,21 +13,32 @@ export interface ChatMessage {
   };
   time: string;
   unreadCount?: number;
+  showReadIndicator?: boolean; // 읽음 표시 여부
 }
 
 // API 스펙에 맞는 새로운 타입들
 export interface MemberInfo {
   memberId: number;
   nickname: string;
-  profileImageUrl: string;
+  profileImageUrl: string | null;
+  lastReadMessageId?: number;
 }
 
 export interface ChatRoomInfo {
+  roomType: "PRIVATE" | "GROUP" | "BAND-APPLICANT" | "BAND-MANAGER";
+  roomId: number;
   chatName: string;
-  imageUrl: string;
-  memberInfos: MemberInfo[];
-  unreadCount: number;
-  lastMessageAt: string;
+  imageUrl: string | null;
+  memberInfo?: {
+    memberId: number;
+    nickname: string;
+    profileImageUrl: string | null;
+    lastReadMessageId: number;
+  };
+  memberInfos?: MemberInfo[];
+  unreadCount: number | null;
+  lastMessageAt: string | null;
+  pinnedAt?: string | null;
 }
 
 export interface RoomMemberInfo {
@@ -57,9 +68,14 @@ export interface AppliedRoomInfo {
 }
 
 export interface ChatRoomsResponse {
-  chatRoomInfos: ChatRoomInfo[];
-  managedRoomInfos: ManagedRoomInfo[];
-  appliedRoomInfos: AppliedRoomInfo[];
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: {
+    chatRoomInfos: ChatRoomInfo[];
+    managedRoomInfos?: ManagedRoomInfo[];
+    appliedRoomInfos?: AppliedRoomInfo[];
+  };
 }
 
 // 친구 채팅방 타입
@@ -115,16 +131,20 @@ export interface CreateChatResponse {
 }
 
 export interface MessagesResponse {
-  roomId: number;
-  messages: {
-    messageId: number;
-    senderId: number;
-    senderName: string;
-    content: string;
-    timestamp: string;
-  }[];
-  hasNext: boolean;
-  lastMessageId: number;
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: {
+    messages: {
+      messageId: number;
+      senderId: number;
+      senderName: string;
+      content: string;
+      timestamp: string;
+    }[];
+    hasNext: boolean;
+    lastMessageId: number;
+  };
 }
 
 export interface JoinResponse {

--- a/src/widgets/Layout/Layout.tsx
+++ b/src/widgets/Layout/Layout.tsx
@@ -17,6 +17,7 @@ export default function Layout() {
     "/profile-detail",
     "/pre-test",
     "/chat-demo",
+    "/home/private-chat",
   ].some((path) => location.pathname.startsWith(path));
   const hideHeader =
     [
@@ -28,6 +29,7 @@ export default function Layout() {
       "/my/setting",
       "/chat-demo",
       "/login",
+      "/home/private-chat",
     ].some((path) => location.pathname.startsWith(path)) ||
     location.pathname === "/my";
 


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요. -->

- #94 

## 📌 PR 내용

<!-- PR 내용을 설명해주세요. -->

<img width="1411" height="701" alt="스크린샷 2025-08-15 오전 4 48 34" src="https://github.com/user-attachments/assets/006fd0e3-3295-447e-8392-2e611367bf44" />

- 개인 채팅 소통 관련 연동

## 🗣️ 팀원에게 공유할 내용

<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->

<img width="781" height="469" alt="스크린샷 2025-08-15 오전 4 51 57" src="https://github.com/user-attachments/assets/a9d9c3ed-4f7f-4a4b-a7b1-add3b10fc8f8" />

채팅 관련 api 반환값 변동으로 인해 불가피하게 현준님쪽 코드 약간 수정해야했습니다.. (src/pages/chat/hooks/useChat.ts)
다른 부분도 불가피한 곳 수정하긴 했는데 현준님쪽에선 사용안되는 것 같긴 합니다..! 다만 바뀐 응답값으로 좀 리팩이 필요한 것 같습니다 ㅜㅠ

개인 채팅에서 본인이 보낸 것을 판단하는 로직이 멤버 아이디로 분별하는 로직인데, 채팅 api쪽에서 이게 필요해서 보안에 문제일 것 같지만.. 임시로 로그인시 로컬스토리지에 멤버아이디 추가하는 식으로 했습니다. (정상동작이 우선이라 판단했어요ㅠㅠ) 추후 더 좋은 로직 제안후 고치겠습니다.
(개인채팅에서는 receiverId 라는 값을 꼭 요구함)

추가로, 현재 읽음 처리 로직이 안되고 있는데.. 계속 시도 중에 있으나 일단 여기까지 올리고 다른 쪽도 수정할게 있어서 그쪽 마치고 다시 착수하겠습니다.

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] 코드 스타일을 eslint/prettier로 맞췄나요?
