### PR TITLE
Feat : 메인페이지에서 join 시 rooms 및 채팅방생성/구독 + lastRead 자동 전송

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+.vite/
 *.local
 
 # Editor directories and files

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -11,6 +11,9 @@ import {
 } from "@/store/userStore";
 import { useRecommendedBands } from "@/features/band/hooks/useBandData";
 import type { BandDetail } from "@/types/band";
+import { joinBandChat, createGroupChat } from "@/store/chatApi";
+import { API } from "@/api/API";
+import { API_ENDPOINTS } from "@/constants";
 
 // 이미지 import
 import homeAlbum3Img from "@/assets/images/home-album3.png";
@@ -206,6 +209,8 @@ const HomePage = () => {
   const [selectedBand, setSelectedBand] = useState<Band | null>(null);
   const [loading, setLoading] = useState(true);
   const { data: recommended = [], isFetching } = useRecommendedBands();
+  // 홈 진입 시 채팅방 목록 선조회(캐시 용도)
+  const [chatRoomInfosCache, setChatRoomInfosCache] = useState<any[]>([]);
 
   // 추천 밴드 프로필 조회 API
   const fetchRecommendedBands = async () => {
@@ -378,15 +383,79 @@ const HomePage = () => {
     }
   };
 
+  // 홈 진입 시 자동으로 채팅방 목록 조회
+  useEffect(() => {
+    const fetchRooms = async () => {
+      try {
+        const roomsRes = await API.get(API_ENDPOINTS.CHAT.ROOMS);
+        const chatInfos = roomsRes?.data?.result?.chatRoomInfos ?? [];
+        setChatRoomInfosCache(chatInfos);
+      } catch (error) {
+        // 조회 실패는 무시 (UI 영향 없음)
+      }
+    };
+    fetchRooms();
+  }, []);
+
   const handleJoinClick = async (band: Band) => {
-    // bandId 49는 그룹 채팅방(roomId 52)로 바로 이동
-    if (band.id === 49) {
-      navigate("/home/chat?roomId=52&roomType=GROUP");
-      return;
+    try {
+      // 1) 사전 지정된 룸 바로 입장(데모 계정용 예외 유지)
+      if (band.id === 49) {
+        navigate("/home/chat?roomId=52&roomType=GROUP");
+        return;
+      }
+
+      // 2) 밴드 조인 API 호출 → roomId 획득 후 이동
+      const bandId = String(band.id);
+      const res = await joinBandChat(bandId);
+      const roomId = (res as any)?.roomId ?? (res as any)?.result?.roomId;
+
+      if (roomId) {
+        navigate(`/home/chat?roomId=${roomId}&roomType=GROUP`);
+        return;
+      }
+
+      // 2-1) 서버에 BAND_JOIN 미구현(404 등) 시 백업 경로:
+      // 우선 캐시에서 탐색, 없으면 즉시 조회 후 탐색
+      try {
+        const chatInfosLocal = chatRoomInfosCache.length
+          ? chatRoomInfosCache
+          : (await API.get(API_ENDPOINTS.CHAT.ROOMS))?.data?.result
+              ?.chatRoomInfos ?? [];
+        const bandRoom = chatInfosLocal.find(
+          (r: any) =>
+            (r?.roomType === "BAND-APPLICANT" ||
+              r?.roomType === "BAND-MANAGER") &&
+            (r?.bandId === band.id || r?.bandName === band.title)
+        );
+        const fallbackRoomId = bandRoom?.roomId;
+        if (fallbackRoomId) {
+          navigate(`/home/chat?roomId=${fallbackRoomId}&roomType=GROUP`);
+          return;
+        }
+      } catch {}
+
+      // 2-2) 목록에도 없으면 방 생성 시도(임시 그룹 채팅)
+      try {
+        const createRes = await createGroupChat({
+          memberIds: [],
+          roomName: band.title || `밴드 모집_${band.id}`,
+        });
+        const newRoomId = (createRes as any)?.roomId;
+        if (newRoomId) {
+          navigate(`/home/chat?roomId=${newRoomId}&roomType=GROUP`);
+          return;
+        }
+      } catch {}
+
+      // 3) roomId를 얻지 못한 경우, 기존 모달로 fallback
+      setSelectedBand(band);
+      setOpen(true);
+    } catch (e) {
+      // 오류 시에도 기존 모달로 fallback
+      setSelectedBand(band);
+      setOpen(true);
     }
-    // 기타는 기존 모달 열기
-    setSelectedBand(band);
-    setOpen(true);
   };
 
   // 이미지 클릭 시 밴드 상세 섹션 이동 등 확장용 (현재는 모달 오픈 동일 동작)

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -416,7 +416,9 @@ const HomePage = () => {
         const name = normalize(r?.chatName || r?.bandName || r?.roomName);
         const byId = Number(r?.bandId);
         return (
-          (roomType === "BAND-APPLICANT" || roomType === "BAND-MANAGER" || roomType === "GROUP") &&
+          (roomType === "BAND-APPLICANT" ||
+            roomType === "BAND-MANAGER" ||
+            roomType === "GROUP") &&
           ((byId && byId === band.id) || (!!name && name === bandName))
         );
       });

--- a/src/pages/Join/Join.tsx
+++ b/src/pages/Join/Join.tsx
@@ -10,6 +10,7 @@ import handRock from "@/assets/icons/join/ic_hand_rock.svg";
 import plus from "@/assets/icons/join/ic_plus.svg";
 import { API } from "@/api/API";
 import { useNavigate } from "react-router-dom";
+import { useWebSocket } from "@/pages/chat/hooks/useWebSocket";
 
 interface MemberInfo {
   memberId: number;
@@ -57,13 +58,23 @@ const Join = () => {
   const [chatRooms, setChatRooms] = useState<ChatRoom[]>([]);
 
   const navigate = useNavigate();
+  const { subscribeUnread, unsubscribeUnread, connect } = useWebSocket();
 
   useEffect(() => {
+    // 목록 화면 진입 시 WebSocket 연결 및 UNREAD 구독
+    connect();
+    subscribeUnread();
+
     const fetchData = async () => {
       const { data } = await API.get("/api/chat/rooms");
       setChatRooms(data.result.chatRoomInfos);
     };
     fetchData();
+
+    return () => {
+      // 목록 화면 이탈 시 UNREAD 구독 해제
+      unsubscribeUnread();
+    };
   }, []);
 
   const renderChatRooms = () => {

--- a/src/pages/chat/hooks/useChat.ts
+++ b/src/pages/chat/hooks/useChat.ts
@@ -26,7 +26,6 @@ export const useChat = () => {
   const currentRoomTypeRef = useRef<"PRIVATE" | "GROUP" | "BAND">("GROUP");
   const lastReadSentIdRef = useRef<number | null>(null);
 
-
   // Auto scroll to bottom when new messages arrive
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -66,19 +65,21 @@ export const useChat = () => {
         const response = await getChatMessages(roomId, cursor);
 
         // API 응답을 ChatMessage 형식으로 변환
-        const chatMessages: ChatMessage[] = response.result.messages.map((msg) => ({
-          id: msg.messageId.toString(),
-          type: "other", // 기본값, 실제로는 현재 사용자 ID와 비교해야 함
-          name: msg.senderName,
-          avatar: "/src/assets/images/profile1.png", // 기본 아바타
-          text: msg.content,
-          time: new Date(msg.timestamp).toLocaleTimeString("ko-KR", {
-            hour: "numeric",
-            minute: "2-digit",
-            hour12: true,
-          }),
-          unreadCount: 0,
-        }));
+        const chatMessages: ChatMessage[] = response.result.messages.map(
+          (msg) => ({
+            id: msg.messageId.toString(),
+            type: "other", // 기본값, 실제로는 현재 사용자 ID와 비교해야 함
+            name: msg.senderName,
+            avatar: "/src/assets/images/profile1.png", // 기본 아바타
+            text: msg.content,
+            time: new Date(msg.timestamp).toLocaleTimeString("ko-KR", {
+              hour: "numeric",
+              minute: "2-digit",
+              hour12: true,
+            }),
+            unreadCount: 0,
+          })
+        );
 
         if (cursor) {
           // 무한 스크롤: 기존 메시지 앞에 추가
@@ -204,7 +205,11 @@ export const useChat = () => {
     if (!Number.isFinite(lastId)) return;
     if (lastReadSentIdRef.current === lastId) return;
     try {
-      sendLastRead(currentRoomId, lastId, currentRoomTypeRef.current || "GROUP");
+      sendLastRead(
+        currentRoomId,
+        lastId,
+        currentRoomTypeRef.current || "GROUP"
+      );
       lastReadSentIdRef.current = lastId;
     } catch (e) {
       // no-op

--- a/src/pages/chat/hooks/useWebSocket.ts
+++ b/src/pages/chat/hooks/useWebSocket.ts
@@ -66,9 +66,14 @@ export const useWebSocket = () => {
   useEffect(() => {
     if (!isConnected) return;
     try {
-      webSocketService.subscribeToUnread((payload) => {
-        console.log("UNREAD_MESSAGE 수신:", payload);
-        // TODO: chatStore에 unread 카운트 반영
+      webSocketService.subscribeToUnread((payload: any) => {
+        // payload 예시: { type: 'UNREAD_MESSAGE', data: { roomId, senderId, content, timestamp } }
+        try {
+          const roomId = Number(payload?.data?.roomId);
+          if (Number.isFinite(roomId)) {
+            chatActions.incrementUnreadCount(roomId);
+          }
+        } catch {}
       });
     } catch (e) {
       console.warn("UNREAD 구독 실패, 연결 상태 재확인 필요", e);

--- a/src/services/WebSocketService.ts
+++ b/src/services/WebSocketService.ts
@@ -372,8 +372,8 @@ class WebSocketService {
       destination,
       body: JSON.stringify(message),
       headers: {
-        "content-type": "application/json;charset=UTF-8"
-      }
+        "content-type": "application/json;charset=UTF-8",
+      },
     });
     console.log("메시지 전송:", message);
   }

--- a/src/services/WebSocketService.ts
+++ b/src/services/WebSocketService.ts
@@ -328,6 +328,15 @@ class WebSocketService {
     console.log(`안읽음 구독 시작 (${destination})`);
   }
 
+  // 안읽음 구독 해제
+  unsubscribeUnread(): void {
+    if (this.unreadSubscription) {
+      this.unreadSubscription.unsubscribe();
+      this.unreadSubscription = null;
+      console.log("안읽음 구독 해제 완료");
+    }
+  }
+
   unsubscribeFromRoom(roomId: string): void {
     const subscription = this.subscriptions.get(roomId);
     if (subscription) {
@@ -369,23 +378,30 @@ class WebSocketService {
     console.log("메시지 전송:", message);
   }
 
-  // 읽음 상태 전송 함수
-  sendReadStatus(roomId: string, messageId: number): void {
+  // 읽음 상태 전송 함수 (roomType에 따라 목적지 분기)
+  sendLastRead(
+    roomId: string,
+    messageId: number,
+    roomType: "PRIVATE" | "GROUP" | "BAND" = "GROUP"
+  ): void {
     if (!this.stompClient || !this.stompClient.connected) {
       console.error("WebSocket이 연결되지 않았습니다.");
       return;
     }
 
-    const destination = `/app/chat/private.lastRead/${roomId}`;
-    
+    const destination =
+      roomType === "PRIVATE"
+        ? `/app/chat/private.lastRead/${roomId}`
+        : `/app/chat/group.lastRead/${roomId}`;
+
     this.stompClient.publish({
       destination,
       body: messageId.toString(),
       headers: {
-        "content-type": "text/plain;charset=UTF-8"
-      }
+        "content-type": "text/plain;charset=UTF-8",
+      },
     });
-    console.log("읽음 상태 전송:", { roomId, messageId });
+    console.log("마지막 읽음 전송:", { roomId, messageId, roomType });
   }
 
   isConnected(): boolean {

--- a/src/store/chatApi.ts
+++ b/src/store/chatApi.ts
@@ -184,6 +184,14 @@ export const leaveChatRoom = async (roomId: string): Promise<LeaveResponse> => {
   return response.data;
 };
 
+// 밴드 채팅방 조인 (bandId 기반 → roomId 반환 기대)
+export const joinBandChat = async (
+  bandId: string
+): Promise<{ roomId: number } | JoinResponse> => {
+  const response = await API.post(API_ENDPOINTS.CHAT.BAND_JOIN(bandId));
+  return response.data;
+};
+
 // 친구 채팅방 목록 조회 (새로운 API 스펙)
 export const getChatFriends = async (): Promise<FriendRoomsResponse> => {
   const response = await API.get(API_ENDPOINTS.CHAT.FRIENDS);

--- a/src/store/chatStore.ts
+++ b/src/store/chatStore.ts
@@ -174,4 +174,17 @@ export const chatActions = {
     chatStore.messages = uniqueMessages;
     chatStore.realtimeMessages = [];
   },
+
+  // 안읽음 카운트 증가 (목록 실시간 반영용)
+  incrementUnreadCount: (roomId: number) => {
+    const idx = chatStore.rooms.findIndex((r) => r.roomId === roomId);
+    if (idx !== -1) {
+      const current = chatStore.rooms[idx].unreadCount;
+      const next = (current ?? 0) + 1;
+      chatStore.rooms[idx] = {
+        ...chatStore.rooms[idx],
+        unreadCount: next,
+      } as unknown as ChatRoom;
+    }
+  },
 };

--- a/src/store/chatStore.ts
+++ b/src/store/chatStore.ts
@@ -145,7 +145,7 @@ export const chatActions = {
     };
 
     chatStore.realtimeMessages.push(chatMessage);
-    
+
     // 현재 채팅방의 메시지에도 추가
     if (chatStore.currentRoomId === wsMessage.roomId.toString()) {
       chatStore.messages.push(chatMessage);
@@ -160,10 +160,11 @@ export const chatActions = {
   mergeRealtimeMessages: () => {
     // 실시간 메시지를 기존 메시지와 통합하고 중복 제거
     const allMessages = [...chatStore.messages, ...chatStore.realtimeMessages];
-    const uniqueMessages = allMessages.filter((message, index, self) => 
-      index === self.findIndex(m => m.id === message.id)
+    const uniqueMessages = allMessages.filter(
+      (message, index, self) =>
+        index === self.findIndex((m) => m.id === message.id)
     );
-    
+
     // 시간순으로 정렬
     uniqueMessages.sort((a, b) => {
       const timeA = new Date(a.time).getTime();


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요. -->

- #이슈번호

## 📌 PR 내용

### 개요
홈 캐러셀 밴드에 대해 채팅방 매핑/생성으로 JOIN 시 즉시 채팅 입장 보장
채팅 목록 화면에서만 /user/queue/unread 구독하여 실시간 미읽음 카운트 반영
채팅방에서 메시지 로드/수신 시 마지막 읽음 상태 자동 전송

### 변경사항
- HomePage.tsx
홈 진입 시 GET /api/chat/rooms 프리페치 → 밴드-룸 매핑
=> 홈에서도 바로 채팅이 들어가야하기 때문
JOIN 시 매핑 우선 입장, 없으면 POST /api/chat/rooms 생성 후 입장, 실패 시 모달 fallback
=>실패 시 모달 폴백인데 이때 모달은 밴드 모달 404에러 폴백

- Join.tsx
화면 진입 시 WebSocket connect + subscribeUnread() 실행, 언마운트 시 unsubscribeUnread()
=>이제 그룹채팅방이니까 최대 안읽은 사람 수가 늘어나는 구조


- useWebSocket.ts
subscribeUnread()/unsubscribeUnread() 공개
sendLastRead(roomId, messageId, roomType) 노출
=> 구독 구독해제 / 마지막으로 읽은 방 메세지 룸타입(그룹,개인)

- WebSocketService.ts
unsubscribeUnread() 추가
sendLastRead() PRIVATE/GROUP 목적지 분기

- useChat.ts
방 입장 시 타입 보관, 메시지 갱신 시 마지막 읽음 자동 전송

- chatStore.ts
incrementUnreadCount(roomId) 추가 (목록 unread 실시간 반영)

- .gitignore
.vite/ 무시 추가

### 동작 방식
홈: 캐러셀 렌더와 병렬로 방 목록 프리페치 → JOIN 클릭 시 매핑 또는 생성으로 /home/chat?roomId=...&roomType=GROUP 이동
목록: /user/queue/unread 수신 시 해당 roomId의 unreadCount +1

채팅방: 메시지 로드/수신 때 sendLastRead 자동 호출

테스트
홈 → JOIN → ‘예’
기존 방 있으면 바로 입장
없으면 생성 후 입장
목록 진입 후 다른 계정에서 메시지 전송 → 목록의 unreadCount 증가 확인
채팅방 입장→ 메시지 로드/수신 후 서버에 lastRead 전송되는지 확인

### 주의/제약
서버 POST /api/chat/bands/{bandId}/join 미제공 → 프론트에서 목록 매핑/생성으로 대체
POST /api/chat/rooms의 memberIds 정책에 따라 생성 실패 가능성 있음(현재 빈 배열)


## 🗣️ 팀원에게 공유할 내용

이게 채팅이 release브랜치를 통해서만 확인이 가능할 것으로 예상됩니다
빠른 작업을 할 때에는 릴리즈에 아닌경우 차근히 메인에 올리고 다시 릴리즈로 가는 브랜치 전략으로 가보겠습니다

그리고 제가 밴드 디테일에서 자꾸 빈 배열이 많아서 오류가 많이 뜨는데 이거를 백엔드 분들한테 어떻게 요청해야할지 고민 중인데.. 머라고 말행야할까요ㅕ


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] 코드 스타일을 eslint/prettier로 맞췄나요?
