### PR TITLE
refactor: Join 페이지 Header responsive design 적용

### DIFF
--- a/src/pages/Join/BandRecruit.tsx
+++ b/src/pages/Join/BandRecruit.tsx
@@ -168,7 +168,7 @@ const BandRecruit = () => {
         </div>
       )}
       <section
-        className="flex flex-col justify-between w-full h-[228px] bg-cover bg-center bg-no-repeat px-[16px] pt-[16px]"
+        className="flex flex-col justify-between relative ml-[calc(50%_-_50vw)] mr-[calc(50%_-_50vw)] h-[228px] bg-cover bg-center bg-no-repeat px-[16px] pt-[16px]"
         style={{
           background: `linear-gradient(0deg, rgba(0, 0, 0, 0.50) 0%, rgba(0, 0, 0, 0.50) 100%), url(${bandDetail?.profileImageUrl}) lightgray 50% / cover no-repeat`,
         }}

--- a/src/pages/Join/Join.tsx
+++ b/src/pages/Join/Join.tsx
@@ -145,54 +145,56 @@ const Join = () => {
 
   return (
     <main className="relative min-h-screen w-[393px] mx-auto px-[24px] pt-[12px]">
-      <h1 className="text-hel-26 text-[#fff]">JOIN</h1>
-      <div className="flex justify-between mt-[24px] w-full relative">
-        <button
-          className="flex justify-center items-center gap-[4px] w-[142px] h-[48px] bg-transparent border-[1.5px] border-[#E9E9E9] rounded-[5px] text-hakgyo-b-17 whitespace-nowrap cursor-pointer text-[#fff]"
-          onClick={() => setOpenChatCategory(!openChatCategory)}
-        >
-          {category} <img src={downArrow} alt="" />
-        </button>
-        {openChatCategory && (
-          <div className="flex flex-col absolute top-[5.5px] translate-y-[33.3%] border-[1.5px] border-[#E9E9E9] rounded-[5px] bg-[#292929]">
-            <CategoryContentBtn
-              onClick={() => {
-                setCategory("전체 채팅방");
-                setOpenChatCategory(!openChatCategory);
-              }}
-            >
-              전체 채팅방
-            </CategoryContentBtn>
-            <CategoryContentBtn
-              onClick={() => {
-                setCategory("일반 채팅방");
-                setOpenChatCategory(!openChatCategory);
-              }}
-            >
-              일반 채팅방
-            </CategoryContentBtn>
-            <CategoryContentBtn
-              onClick={() => {
-                setCategory("밴드 채팅방");
-                setOpenChatCategory(!openChatCategory);
-              }}
-            >
-              밴드 채팅방
-            </CategoryContentBtn>
-          </div>
-        )}
-        <div className="flex">
+      <header className="ml-[calc(50%_-_50vw)] mr-[calc(50%_-_50vw)] px-[24px] w-screen">
+        <h1 className="text-hel-26 text-[#fff]">JOIN</h1>
+        <div className="flex justify-between mt-[24px] w-full relative">
           <button
-            className="p-[0] bg-transparent border-none cursor-pointer"
-            onClick={() => navigate("/join/saved-band")}
+            className="flex justify-center items-center gap-[4px] w-[142px] h-[48px] bg-transparent border-[1.5px] border-[#E9E9E9] rounded-[5px] text-hakgyo-b-17 whitespace-nowrap cursor-pointer text-[#fff]"
+            onClick={() => setOpenChatCategory(!openChatCategory)}
           >
-            <img src={guitar} alt="" />
+            {category} <img src={downArrow} alt="" />
           </button>
-          {/* <button className="p-[0] bg-transparent border-none cursor-pointer">
+          {openChatCategory && (
+            <div className="flex flex-col absolute top-[5.5px] translate-y-[33.3%] border-[1.5px] border-[#E9E9E9] rounded-[5px] bg-[#292929]">
+              <CategoryContentBtn
+                onClick={() => {
+                  setCategory("전체 채팅방");
+                  setOpenChatCategory(!openChatCategory);
+                }}
+              >
+                전체 채팅방
+              </CategoryContentBtn>
+              <CategoryContentBtn
+                onClick={() => {
+                  setCategory("일반 채팅방");
+                  setOpenChatCategory(!openChatCategory);
+                }}
+              >
+                일반 채팅방
+              </CategoryContentBtn>
+              <CategoryContentBtn
+                onClick={() => {
+                  setCategory("밴드 채팅방");
+                  setOpenChatCategory(!openChatCategory);
+                }}
+              >
+                밴드 채팅방
+              </CategoryContentBtn>
+            </div>
+          )}
+          <div className="flex">
+            <button
+              className="p-[0] bg-transparent border-none cursor-pointer"
+              onClick={() => navigate("/join/saved-band")}
+            >
+              <img src={guitar} alt="" />
+            </button>
+            {/* <button className="p-[0] bg-transparent border-none cursor-pointer">
             <img src={moodHeart} alt="" />
           </button> */}
+          </div>
         </div>
-      </div>
+      </header>
       <section className="flex flex-col gap-[19px] mt-[48px] w-full">
         {renderChatRooms()}
       </section>

--- a/src/pages/Join/_components/JoinHeader.tsx
+++ b/src/pages/Join/_components/JoinHeader.tsx
@@ -6,6 +6,7 @@ interface JoinHeaderProps {
   enableConfirmBtn: boolean;
   confirmBtnContent?: string;
   onClick: () => void;
+  horizontalPadding?: number;
 }
 
 /**
@@ -15,15 +16,23 @@ interface JoinHeaderProps {
  * @param {boolean} enableConfirmBtn - 확인 버튼 활성화 여부
  * @param {string} [confirmBtnContent] - optional, default: "확인"
  * @param {() => void} onClick - onClick
+ * @param {number} [horizontalPadding] - optional, default: 16
  */
 const JoinHeader = ({
   enableConfirmBtn,
   confirmBtnContent = "확인",
   onClick,
+  horizontalPadding = 16,
 }: JoinHeaderProps) => {
   const navigate = useNavigate();
+  const horizontalPaddingClassName = `px-[${horizontalPadding}px]`;
   return (
-    <div className="flex justify-between mb-[16px] w-full">
+    <div
+      className={clsx(
+        "flex justify-between ml-[calc(50%_-_50vw)] mr-[calc(50%_-_50vw)] mb-[16px] w-screen",
+        horizontalPaddingClassName
+      )}
+    >
       <button
         className="p-[0] bg-transparent border-none cursor-pointer"
         onClick={() => navigate(-1)}

--- a/src/pages/Join/saved_band/SavedBand.tsx
+++ b/src/pages/Join/saved_band/SavedBand.tsx
@@ -36,7 +36,7 @@ const SavedBand = () => {
   }, []);
   return (
     <main className="relative min-h-screen w-[393px] mx-auto px-[24px] pt-[12px]">
-      <div className="flex justify-end w-full mb-[24px]">
+      <div className="flex justify-end ml-[calc(50%_-_50vw)] mr-[calc(50%_-_50vw)] w-screen px-[24px] mb-[24px]">
         <button
           className="p-[0] bg-transparent border-none cursor-pointer"
           onClick={() => {

--- a/src/pages/Join/saved_band/SavedBandDetail.tsx
+++ b/src/pages/Join/saved_band/SavedBandDetail.tsx
@@ -1,5 +1,5 @@
 import guitarActivated from "@/assets/icons/join/ic_guitar_activated.svg";
-import moodHeart from "@/assets/icons/join/ic_mood_heart.svg";
+// import moodHeart from "@/assets/icons/join/ic_mood_heart.svg";
 import volumeOff from "@/assets/icons/join/ic_volume_off.svg";
 import star from "@/assets/icons/join/ic_star.svg";
 import { useEffect, useState } from "react";
@@ -62,13 +62,13 @@ const SavedBandDetail = () => {
 
   return (
     <main className="relative min-h-screen w-[393px] mx-auto px-[24px] pt-[12px]">
-      <div className="flex justify-end w-full mb-[24px]">
+      <div className="flex justify-end ml-[calc(50%_-_50vw)] mr-[calc(50%_-_50vw)] px-[24px] w-screen mb-[24px]">
         <button className="p-[0] bg-transparent border-none cursor-pointer">
           <img src={guitarActivated} alt="" className="size-[48px]" />
         </button>
-        <button className="p-[0] bg-transparent border-none cursor-pointer">
+        {/* <button className="p-[0] bg-transparent border-none cursor-pointer">
           <img src={moodHeart} alt="" className="size-[48px]" />
-        </button>
+        </button> */}
       </div>
 
       <section className="flex flex-col items-center">


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요. -->

- #127 

## 📌 PR 내용

<!-- PR 내용을 설명해주세요. -->

- refactor: Join 페이지 Header responsive design 적용

## 🗣️ 팀원에게 공유할 내용

<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->

기존 페이지 레이아웃 내부에서 커스텀 header를 만든 방식이라, 대부분 아래의 코드 기반으로 수정했습니다:
`<header className="ml-[calc(50%_-_50vw)] mr-[calc(50%_-_50vw)] px-[24px] w-screen">`



## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
- [ ] 코드 스타일을 eslint/prettier로 맞췄나요?
